### PR TITLE
Make encrypt key correct length

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -78,7 +78,7 @@ return [
 	|
 	*/
 
-	'key' => 'wDSWqqKRNjpYRWhYnmBCjxFQTecKMy',
+	'key' => 'D6Syi0yWTfjJBee6HVBLAmXvviEWnCzU',
 
 	'cipher' => MCRYPT_RIJNDAEL_128,
 


### PR DESCRIPTION
Generates

```
mcrypt_encrypt(): Key of size 30 not supported by this algorithm. Only keys of sizes 16, 24 or 32 supported
```
